### PR TITLE
[Fix] Verify user authorization for DELETE `/api/projects/requests/:id`

### DIFF
--- a/endpoints.md
+++ b/endpoints.md
@@ -258,7 +258,7 @@ Edit project info, change status of project (e.g. to complete), and remove proje
 
 ### Body Parameters
 
-If any of these values are not passed in, the value will remain the same. If any value is provided, the old value will be provided.
+If any of these values are not passed in, the value will remain the same. If any value is provided, the old value will be replaced.
 
 `name`: project name  
 `description`: project description  

--- a/src/routes/controllers/projects/manageMemberRequest.js
+++ b/src/routes/controllers/projects/manageMemberRequest.js
@@ -5,8 +5,6 @@ const manageMemberRequest = async (req, res) => {
         const { id } = req.params; // id of join request
         const { decision } = req.body; // decision made by project creator (if true, accepted; if false, denied)
 
-        // TODO: verify project creator
-
         // verify decision is passed in
         if (typeof decision !== 'boolean')
             return res

--- a/src/routes/controllers/projects/updateProject.js
+++ b/src/routes/controllers/projects/updateProject.js
@@ -1,7 +1,5 @@
 const { pool } = require('../../../utils/db');
 
-// TODO: don't delete all instead remove rest and insert rest
-
 const updateProject = async (req, res) => {
     try {
         const { username } = req; // username passed after authenticating token
@@ -31,6 +29,9 @@ const updateProject = async (req, res) => {
                 id,
             ]);
 
+        // TODO: don't delete all skills instead remove skills not passed in and 
+        // insert rest that are not already included
+
         // change project skills if passed in body
         if (typeof skills !== 'undefined') {
             // delete all skills currently listed for the project
@@ -50,6 +51,10 @@ const updateProject = async (req, res) => {
             }
         }
 
+
+        // TODO: don't delete all tags instead remove tags not passed in and 
+        // insert rest that are not already included
+
         // change project tags if passed in body
         if (typeof tags !== 'undefined') {
             // delete all tags currently listed for the project
@@ -67,6 +72,10 @@ const updateProject = async (req, res) => {
                 );
             }
         }
+
+
+        // TODO: don't delete all members instead remove members not passed in and 
+        // insert rest that are not already included
 
         // change project members if passed in body
         if (typeof members !== 'undefined') {

--- a/src/routes/projects.js
+++ b/src/routes/projects.js
@@ -23,6 +23,6 @@ router.post('/', authenticateToken, createProject);
 router.post('/:id/follow', authenticateToken, followProject);
 router.post('/:id/requests', authenticateToken, createMemberRequest);
 router.put('/:id', authenticateToken, verifyProjectCreator, updateProject);
-router.delete('/requests/:id', authenticateToken, manageMemberRequest);
+router.delete('/requests/:id', authenticateToken, verifyProjectCreator, manageMemberRequest);
 
 module.exports = router;

--- a/src/utils/seedDB.js
+++ b/src/utils/seedDB.js
@@ -1,11 +1,11 @@
 const axios = require('axios');
 
-const PROXY = process.env.PROXY || 'http://localhost:5000';
+const PROXY = process.env.PROXY || 'http://localhost:5000/api/';
 
 const options = [
     {
         method: 'POST',
-        url: `${PROXY}/api/auth/signup`,
+        url: `${PROXY}/auth/signup`,
         headers: { 'Content-Type': 'application/json' },
         data: {
             username: 'saifulislam',
@@ -18,7 +18,7 @@ const options = [
     },
     {
         method: 'POST',
-        url: `${PROXY}/api/auth/signup`,
+        url: `${PROXY}/auth/signup`,
         headers: { 'Content-Type': 'application/json' },
         data: {
             username: 'johndoe',
@@ -31,7 +31,7 @@ const options = [
     },
     {
         method: 'POST',
-        url: `${PROXY}/api/auth/signup`,
+        url: `${PROXY}/auth/signup`,
         headers: { 'Content-Type': 'application/json' },
         data: {
             username: 'janedoe',
@@ -44,7 +44,7 @@ const options = [
     },
     {
         method: 'POST',
-        url: `${PROXY}/api/auth/signup`,
+        url: `${PROXY}/auth/signup`,
         headers: { 'Content-Type': 'application/json' },
         data: {
             username: 'bob',


### PR DESCRIPTION
Changes were made to ensure that the user performing the request is the project creator for the project that the member request (`:id`) corresponds to.

Some minor changes were made to inline and endpoints documentations for the `updateProject` controller.

The proxy for local database seeding has been updated as well.