### PR TITLE
[Feature] GET `/users/createdProjects`

### DIFF
--- a/endpoints.md
+++ b/endpoints.md
@@ -9,6 +9,7 @@ Note: All routes are prefixed by `/api`.
 | [🔗](#post-authsignin)                              | `/auth/`          | POST `/auth/signin`                                       | Sign in                        | ✅     |
 | [🔗](#post-authsignup)                              |                   | POST `/auth/signup`                                       | Sign up                        | ✅     |
 | [🔗](#get-usersid)                                  | `/users/`         | GET `/users/:id`                                          | Profile page                   | ✅     |
+| [🔗](#get-userscreatedprojects)                     | `/users/`         | GET `/users/createdProjects`                              | Member approval                  | ✅     |
 | [🔗](#put-usersid)                                  |                   | PUT `/users/:id`                                          | Profile page                   | ✅     |
 | [🔗](#get-projects)                                 | `/projects/`      | GET `/projects`                                           | Project search and suggestions | ✅     |
 | [🔗](#get-projectsid)                               |                   | GET `/projects/:id`                                       | Project page                   | ✅     |
@@ -113,6 +114,22 @@ If successful, results in `200` status code and profile info in the form of key-
 
 Otherwise, results in a `500` error status code with a message about the error.
 
+## GET `/users/createdProjects`
+
+### Description
+
+Get projects a user has created
+
+### Header
+
+`authorization`: token
+
+### Result
+
+If successful, results in `200` status code and an array containing objects with some info of all projects in the form of key-value pairs. Otherwise, results in a `500` error status code with a message about the error.
+
+For retrieving full info about a project, refer to [GET /projects/:id endpoint](#get-projectsid)
+
 ## PUT `/users/:id`
 
 ### Description
@@ -197,10 +214,6 @@ Get information about a project (basic info, skills, tags, members, updates, etc
 ### Result
 
 If successful, results in `200` status code and project info in the form of key-value pairs. Otherwise, results in a `400` or `500` error status code with a message about the error.
-
-### Description
-
-Get info of project with ID of project
 
 ## GET `/projects/filters`
 

--- a/src/routes/controllers/users/getCreatedProjects.js
+++ b/src/routes/controllers/users/getCreatedProjects.js
@@ -1,0 +1,21 @@
+const { pool } = require('../../../utils/db');
+
+const getCreatedProjects = async (req, res) => {
+    try {
+        const { username } = req; // username passed after authenticating token
+
+        // Returns some info about the project
+        // For getting full info about a project, refer to documentation
+        const { rows } = await pool.query(
+            'SELECT id, name, description FROM "Project" WHERE creator = $1',
+            [username]
+        );
+
+        return res.status(200).json({ projects: rows });
+    } catch (err) {
+        console.log(err);
+        return res.status(500).json({ msg: 'Internal server error' });
+    }
+};
+
+module.exports = getCreatedProjects;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -2,10 +2,12 @@ const express = require('express');
 const router = express.Router();
 
 const editUser = require('./controllers/users/editUser');
+const getCreatedProjects = require('./controllers/users/getCreatedProjects');
 const getUserInfo = require('./controllers/users/getUserInfo');
 
 const authenticateToken = require('./middlewares/authenticateToken');
 
+router.get('/createdProjects', authenticateToken, getCreatedProjects);
 router.get('/:id', getUserInfo);
 router.put('/:id', authenticateToken, editUser);
 


### PR DESCRIPTION
This new endpoint allows for viewing the projects a user has created. The use of this endpoint makes things a whole lot easier and efficient for the member approval component of the project, which requires finding out a user's created projects. 

Otherwise, to get a user's created projects, the GET `/projects` response would have to be iterated through to find projects where the creator is the user (a hassle and very inefficient). 

Looking at it now, another option could have been to add another query parameter (`creator`) to the GET `/projects?skill[]=value1&tag[]=value2&search=value3` endpoint to query projects by the project creator.