### PR TITLE
[Fix] Project creation and search

### DIFF
--- a/src/routes/controllers/projects/createProject.js
+++ b/src/routes/controllers/projects/createProject.js
@@ -67,7 +67,7 @@ const createProject = async (req, res) => {
         }
 
         await Promise.all(promises);
-        return res.status(201).json({ msg: 'Project created' });
+        return res.status(201).json({ id: id, msg: 'Project created' });
     } catch (err) {
         console.error(err);
         return res.status(500).json({ msg: 'Internal server error' });

--- a/src/routes/controllers/projects/getAllProjects.js
+++ b/src/routes/controllers/projects/getAllProjects.js
@@ -27,8 +27,8 @@ const getAllProjects = async (req, res) => {
                                             WHERE tag = ANY ($2)
                                             GROUP BY project_id
                                             HAVING COUNT(DISTINCT tag) = array_length($1, 1))
-                                AND (SELECT bool_or(position(searchTerm in name) > 0)
-                                    FROM unnest($3::text[]) searchTerm)`,
+                                AND (SELECT bool_or(strpos(name, searchTerm) > 0)
+                                    FROM unnest($3::citext[]) searchTerm)`,
                         [req.query.skill, req.query.tag, searchTerms]
                     );
                 } else if (req.query.skill) {
@@ -40,8 +40,8 @@ const getAllProjects = async (req, res) => {
                                         WHERE skill = ANY ($1)
                                         GROUP BY project_id
                                         HAVING COUNT(DISTINCT skill) = array_length($1, 1))
-                                    AND (SELECT bool_or(position(searchTerm in name) > 0)
-                                        FROM unnest($2::text[]) searchTerm)`,
+                                    AND (SELECT bool_or(strpos(name, searchTerm) > 0)
+                                        FROM unnest($2::citext[]) searchTerm)`,
                             [req.query.skill, searchTerms]
                         );
                 } else if (req.query.tag) {
@@ -53,16 +53,16 @@ const getAllProjects = async (req, res) => {
                                     WHERE tag = ANY ($1)
                                     GROUP BY project_id
                                     HAVING COUNT(DISTINCT tag) = array_length($1, 1))
-                                AND (SELECT bool_or(position(searchTerm in name) > 0)
-                                    FROM unnest($2::text[]) searchTerm)`,
+                                AND (SELECT bool_or(strpos(name, searchTerm) > 0)
+                                    FROM unnest($2::citext[]) searchTerm)`,
                         [req.query.tag, searchTerms]
                     );
                 } else {
                     projects = await pool.query(
                         `SELECT id,name,description,creator,status,created_at 
                         FROM "Project" 
-                        WHERE (SELECT bool_or(position(searchTerm in name) > 0)
-                                FROM unnest($2::text[]) searchTerm)`,
+                        WHERE (SELECT bool_or(strpos(name, searchTerm) > 0)
+                                FROM unnest($2::citext[]) searchTerm)`,
                         [searchTerms]
                     );
                 }

--- a/src/routes/controllers/projects/getAllProjects.js
+++ b/src/routes/controllers/projects/getAllProjects.js
@@ -57,6 +57,14 @@ const getAllProjects = async (req, res) => {
                                     FROM unnest($2::text[]) searchTerm)`,
                         [req.query.tag, searchTerms]
                     );
+                } else {
+                    projects = await pool.query(
+                        `SELECT id,name,description,creator,status,created_at 
+                        FROM "Project" 
+                        WHERE (SELECT bool_or(position(searchTerm in name) > 0)
+                                FROM unnest($2::text[]) searchTerm)`,
+                        [searchTerms]
+                    );
                 }
             } else {
                 if (req.query.skill && req.query.tag) {

--- a/src/routes/controllers/projects/getAllProjects.js
+++ b/src/routes/controllers/projects/getAllProjects.js
@@ -26,9 +26,12 @@ const getAllProjects = async (req, res) => {
                                             FROM "ProjectTag"
                                             WHERE tag = ANY ($2)
                                             GROUP BY project_id
-                                            HAVING COUNT(DISTINCT tag) = array_length($1, 1))
-                                AND (SELECT bool_or(strpos(name, searchTerm) > 0)
-                                    FROM unnest($3::citext[]) searchTerm)`,
+                                            HAVING COUNT(DISTINCT tag) = array_length($2, 1))
+                                AND ((SELECT bool_or(strpos(name, searchTerm) > 0)
+                                        FROM unnest($3::citext[]) searchTerm)
+                                    OR id IN (SELECT project_id 
+                                            FROM "ProjectTag"
+                                            WHERE tag = ANY ($3)))`,
                         [req.query.skill, req.query.tag, searchTerms]
                     );
                 } else if (req.query.skill) {
@@ -40,8 +43,11 @@ const getAllProjects = async (req, res) => {
                                         WHERE skill = ANY ($1)
                                         GROUP BY project_id
                                         HAVING COUNT(DISTINCT skill) = array_length($1, 1))
-                                    AND (SELECT bool_or(strpos(name, searchTerm) > 0)
-                                        FROM unnest($2::citext[]) searchTerm)`,
+                                    AND ((SELECT bool_or(strpos(name, searchTerm) > 0)
+                                            FROM unnest($2::citext[]) searchTerm)
+                                        OR id IN (SELECT project_id 
+                                                FROM "ProjectTag"
+                                                WHERE tag = ANY ($2)))`,
                             [req.query.skill, searchTerms]
                         );
                 } else if (req.query.tag) {
@@ -53,16 +59,22 @@ const getAllProjects = async (req, res) => {
                                     WHERE tag = ANY ($1)
                                     GROUP BY project_id
                                     HAVING COUNT(DISTINCT tag) = array_length($1, 1))
-                                AND (SELECT bool_or(strpos(name, searchTerm) > 0)
-                                    FROM unnest($2::citext[]) searchTerm)`,
+                                AND ((SELECT bool_or(strpos(name, searchTerm) > 0)
+                                        FROM unnest($2::citext[]) searchTerm)
+                                    OR id IN (SELECT project_id 
+                                            FROM "ProjectTag"
+                                            WHERE tag = ANY ($2)))`,
                         [req.query.tag, searchTerms]
                     );
                 } else {
                     projects = await pool.query(
                         `SELECT id,name,description,creator,status,created_at 
                         FROM "Project" 
-                        WHERE (SELECT bool_or(strpos(name, searchTerm) > 0)
-                                FROM unnest($2::citext[]) searchTerm)`,
+                        WHERE ((SELECT bool_or(strpos(name, searchTerm) > 0)
+                                FROM unnest($1::citext[]) searchTerm)
+                                OR id IN (SELECT project_id 
+                                            FROM "ProjectTag"
+                                            WHERE tag = ANY ($1)))`,
                         [searchTerms]
                     );
                 }
@@ -80,7 +92,7 @@ const getAllProjects = async (req, res) => {
                                     FROM "ProjectTag"
                                     WHERE tag = ANY ($2)
                                     GROUP BY project_id
-                                    HAVING COUNT(DISTINCT tag) = array_length($1, 1))`,
+                                    HAVING COUNT(DISTINCT tag) = array_length($2, 1))`,
                         [req.query.skill, req.query.tag]
                     );
                 } else if (req.query.skill) {


### PR DESCRIPTION
- returned `id` upon project creation to enable a redirect to the project page after creation
- fixed a bug where keyword searches performed without any skill or tag parameters provided would fail
- fixed a bug where some of the results returned would only match with some of the skills/tags provided due to a SQL query parameter mismatch
- expanded the scope of keyword searches to check for any matches in a project's tags along with its name