### PR TITLE
[Fix] Modifying project members when updating project

### DIFF
--- a/endpoints.md
+++ b/endpoints.md
@@ -110,7 +110,11 @@ Get user profile info (and ratings)
 
 ### Result
 
-If successful, results in `200` status code and profile info in the form of key-value pairs. Be mindful that the `visitingUserMutualProjects` property may not always exist (that is, the key won't exist). It exists when the token is valid. When the token is invalid or there is not one given, the property won't exist. Another thing to be mindful about is that the value will be an empty array when the token is valid but the visiting user has no mutual projects.
+If successful, results in `200` status code and profile info in the form of key-value pairs. 
+
+`projectMemberships` contains projects that the user is a part of currently or was in the past.
+
+Be mindful that the `visitingUserMutualProjects` property may not always exist (that is, the key won't exist). It exists when the token is valid. When the token is invalid or there is not one given, the property won't exist. Another thing to be mindful about is that the value will be an empty array when the token is valid but the visiting user has no mutual projects.
 
 Otherwise, results in a `500` error status code with a message about the error.
 
@@ -477,11 +481,11 @@ The user associated with the token should match the user specified by `id`. Othe
 
 ### Description
 
-Get project updates for a user
+Get project updates for a user that they view on their feed
 
 ### Header
 
-`authorization`: token (if exists)
+`authorization`: token
 
 ### Result
 

--- a/src/models/ProjectMember.js
+++ b/src/models/ProjectMember.js
@@ -2,6 +2,7 @@ const ProjectMember =
     'CREATE TABLE IF NOT EXISTS "ProjectMember"( \
         project_id INT, \
         username CITEXT, \
+        status BOOLEAN DEFAULT TRUE NOT NULL, \
         created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP NOT NULL, \
         PRIMARY KEY (project_id, username), \
         FOREIGN KEY (project_id) REFERENCES "Project"(id), \

--- a/src/routes/controllers/projects/createMemberRequest.js
+++ b/src/routes/controllers/projects/createMemberRequest.js
@@ -28,7 +28,9 @@ const createMemberRequest = async (req, res) => {
             [id, username]
         );
         if (alreadyMember[0].exists)
-            return res.status(400).json({ msg: 'Already a member' });
+            return res.status(400).json({
+                msg: 'Already a member! If you were previously a member, the creator has to manually add you.',
+            });
 
         // check if a request was already made by user in the past
         const { rows: requestExists } = await pool.query(

--- a/src/routes/controllers/projects/getProject.js
+++ b/src/routes/controllers/projects/getProject.js
@@ -62,7 +62,7 @@ const getProject = async (req, res) => {
         const { rows: members } = await pool.query(
             'SELECT username, created_at AS "joinedAt" \
             FROM "ProjectMember" \
-            WHERE project_id = $1',
+            WHERE project_id = $1 AND status = true',
             [id]
         );
 
@@ -155,7 +155,7 @@ const getProject = async (req, res) => {
                 'SELECT exists( \
                     SELECT created_at \
                     FROM "ProjectMember" \
-                    WHERE username = $1 AND project_id = $2 \
+                    WHERE username = $1 AND project_id = $2 AND status = true \
                 )',
                 [username, id]
             );
@@ -173,17 +173,15 @@ const getProject = async (req, res) => {
 
         // get mutual skills between project and user
         let { rows: userMutualSkills } = await pool.query({
-            text: 
-            'SELECT "UserSkill".skill \
+            text: 'SELECT "UserSkill".skill \
             FROM "UserSkill" \
             INNER JOIN "ProjectSkill" \
             ON "UserSkill".skill = "ProjectSkill".skill \
             WHERE username = $1 \
             AND project_id = $2',
             values: [username, id],
-            rowMode: 'array'
-        }
-        )
+            rowMode: 'array',
+        });
         userMutualSkills = userMutualSkills.flat(); // flat nested array
 
         const projectInfo = {
@@ -202,7 +200,7 @@ const getProject = async (req, res) => {
             isUserAMember: isUserAMember,
             isUserFollowing: isUserFollowing,
             isValidUser: isValidUser,
-            userMutualSkills: userMutualSkills
+            userMutualSkills: userMutualSkills,
         };
 
         return res.status(200).json(projectInfo);

--- a/src/routes/controllers/users/getUserInfo.js
+++ b/src/routes/controllers/users/getUserInfo.js
@@ -59,7 +59,7 @@ const getUserInfo = async (req, res) => {
             [usernameFromRoute]
         );
 
-        // gather the projects that the user is part of
+        // gather the projects that the user is part of or was a part of in the past
         const { rows: projectMemberships } = await pool.query(
             '\
             SELECT \
@@ -93,6 +93,7 @@ const getUserInfo = async (req, res) => {
         let canEdit = usernameFromToken === usernameFromRoute ? true : false;
 
         // check if visiting user can review the user of the profile they are visiting
+        // TODO: make sure timelines are in sync (they both worked on project(s) at the same time)
         let canReview = false;
         let mutualProjects;
         if (
@@ -115,7 +116,10 @@ const getUserInfo = async (req, res) => {
                     [usernameFromToken, usernameFromRoute]
                 );
             if (hasMutualProjects) {
-                canReview = await checkReviewability(usernameFromToken, usernameFromRoute);
+                canReview = await checkReviewability(
+                    usernameFromToken,
+                    usernameFromRoute
+                );
                 mutualProjects = projects;
             }
         }


### PR DESCRIPTION
Before, there was an issue where project members could not be removed when updating a project due to rows In the ProjectUpdate table referencing the row(s) in ProjectMember. As further clarification, if a project member created an update for the project, they cannot be removed from the project as per foreign key constraints (row(s) in `ProjectUpdate` referencing the row in `ProjectMember`).

Now, I introduced a new `status` column in the `ProjectMember` table to "delete" the member from the project (by setting the value for that column to `false`). Changes were made accordingly in other SQL queries that interact with the `ProjectMember` table.