### PR TITLE
[Fix] Check if a user exists before getting the user's info

### DIFF
--- a/endpoints.md
+++ b/endpoints.md
@@ -116,7 +116,7 @@ If successful, results in `200` status code and profile info in the form of key-
 
 Be mindful that the `visitingUserMutualProjects` property may not always exist (that is, the key won't exist). It exists when the token is valid. When the token is invalid or there is not one given, the property won't exist. Another thing to be mindful about is that the value will be an empty array when the token is valid but the visiting user has no mutual projects.
 
-Otherwise, results in a `500` error status code with a message about the error.
+Otherwise, results in a `400` or `500` error status code with a message about the error.
 
 ## GET `/users/createdProjects`
 

--- a/src/routes/controllers/users/getUserInfo.js
+++ b/src/routes/controllers/users/getUserInfo.js
@@ -7,6 +7,22 @@ const getUserInfo = async (req, res) => {
         const { id: usernameFromRoute } = req.params; // username of the profile being visited
         const token = req.headers['authorization']; // token comes in an authorization header
 
+        // see if user from route exists
+        const { rows: userExists } = await pool.query(
+            `
+            SELECT exists(
+                SELECT username
+                FROM "User"
+                WHERE username = $1
+                )
+            `,
+            [usernameFromRoute]
+        );
+        if (!userExists[0].exists)
+            return res.status(400).json({
+                msg: 'No such user exists',
+            });
+
         // get username from token
         let usernameFromToken;
         if (typeof token === 'string') {


### PR DESCRIPTION
Before, obtaining an unexisting user's info would result in a 200 request, which does not make sense. Now, it is checked if the user actually exists, and if not, a 400 status code is sent.